### PR TITLE
Update pancakeswap-extended.json

### DIFF
--- a/lists/pancakeswap-extended.json
+++ b/lists/pancakeswap-extended.json
@@ -1620,6 +1620,14 @@
       "decimals": 18,
       "logoURI": "https://tokens.pancakeswap.finance/images/0x734548a9e43d2D564600b1B2ed5bE9C2b911c6aB.png"
     },
+{
+      "name": "Carbon Protocol",
+      "symbol": "SWTH",
+      "address": "0xC0ECB8499D8dA2771aBCbF4091DB7f65158f1468",
+      "chainId": 56,
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/3645/thumb/SWTH_Symbol_Origin.png?1645000262"
+    },
     {
       "name": "ConstitutionDAO",
       "symbol": "PEOPLE",


### PR DESCRIPTION
SWH was migrated and upgraded to SWTH previously. Currently updating SWTH by Carbon Protocol to the extended token list. 