### PR TITLE
fix: magic token name

### DIFF
--- a/lists/pancakeswap-arbitrum-default.json
+++ b/lists/pancakeswap-arbitrum-default.json
@@ -1,10 +1,10 @@
 {
   "name": "PancakeSwap Arbitrum Default",
-  "timestamp": "2024-05-02T17:36:35.266Z",
+  "timestamp": "2024-05-22T04:04:08.074Z",
   "version": {
     "major": 0,
     "minor": 0,
-    "patch": 20
+    "patch": 21
   },
   "logoURI": "https://pancakeswap.finance/logo.png",
   "keywords": [

--- a/lists/pancakeswap-arbitrum-default.json
+++ b/lists/pancakeswap-arbitrum-default.json
@@ -214,7 +214,7 @@
       "logoURI": "https://tokens.pancakeswap.finance/images/arbitrum/0x3082CC23568eA640225c2467653dB90e9250AaA0.png"
     },
     {
-      "name": "Magic Internet Money",
+      "name": "MAGIC",
       "symbol": "MAGIC",
       "address": "0x539bdE0d7Dbd336b79148AA742883198BBF60342",
       "chainId": 42161,

--- a/src/tokens/pancakeswap-arbitrum-default.json
+++ b/src/tokens/pancakeswap-arbitrum-default.json
@@ -200,7 +200,7 @@
     "logoURI": "https://tokens.pancakeswap.finance/images/arbitrum/0x3082CC23568eA640225c2467653dB90e9250AaA0.png"
   },
   {
-    "name": "Magic Internet Money",
+    "name": "MAGIC",
     "symbol": "MAGIC",
     "address": "0x539bdE0d7Dbd336b79148AA742883198BBF60342",
     "chainId": 42161,


### PR DESCRIPTION
The name "Magic Internet Money" is for $MIM but was being used for $MAGIC as well.  
Name for $MAGIC has been changed to `MAGIC`.