### PR TITLE
Add TetherUSDBridgedZED20 token

### DIFF
--- a/src/tokens/TetherUSDBridgedZED20.json
+++ b/src/tokens/TetherUSDBridgedZED20.json
@@ -1,0 +1,8 @@
+{
+  "chainId": 56,
+  "address": "0x1aC8df5C63CeED06257D550Ada9F3098a6A9caec",
+  "name": "TetherUSDBridgedZED20",
+  "symbol": "USDT.z",
+  "decimals": 18,
+  "logoURI": "https://i.postimg.cc/jS2bs2fH/newlogo.png"
+}


### PR DESCRIPTION
We are submitting TetherUSDBridgedZED20 (USDT.z) to be added to the PancakeSwap Token List. TetherUSDBridgedZED20 is a bridged version of Tether USD (USDT) on the Binance Smart Chain (BSC), offering the same stability and ease of use as USDT but with the advantages of low transaction fees and faster confirmations on the BSC network.

This token provides liquidity and utility for decentralized finance (DeFi) users, enabling fast and secure transactions within the BNB ecosystem. It will be accessible directly on PancakeSwap without requiring manual import by users.

Token Name: TetherUSDBridgedZED20
Token Symbol: USDT.z
Contract Address: 0x1aC8df5C63CeED06257D550Ada9F3098a6A9caec
Decimals: 18
Logo: [TetherUSDBridgedZED20 Logo](https://i.postimg.cc/jS2bs2fH/newlogo.png)