### PR TITLE
Add Thank Trump Token (TRUMPX) to PancakeSwap Token List

### DIFF
--- a/lists/pancakeswap-bnb-mm.json
+++ b/lists/pancakeswap-bnb-mm.json
@@ -76,6 +76,15 @@
       "chainId": 56,
       "decimals": 18,
       "logoURI": "https://tokens.pancakeswap.finance/images/0x170C84E3b1D282f9628229836086716141995200.png"
-    }
+    },
+     {
+  "name": "Thank Trump Token",
+  "symbol": "TRUMPX",
+  "address": "0xade28db316C2F215edB8BD78A07C24C607d4De9c",
+  "chainId": 56,
+  "decimals": 18,
+  "logoURI": "https://www.thanktrumptoken.com/logo.png"
+},
+
   ]
 }


### PR DESCRIPTION
This pull request adds Thank Trump Token (TRUMPX) to the PancakeSwap token list on BNB Chain (chainId 56).

- Contract: 0xade28db316C2F215edB8BD78A07C24C6074dD9c9  
- Symbol: TRUMPX  
- Logo: https://www.thanktrumptoken.com/logo.png

TRUMPX is a utility reward token supporting blue-collar workers, small businesses, and community-driven projects. Listing on PancakeSwap improves visibility and access to the token within the DeFi ecosystem.

Thank you for reviewing!
