### PR TITLE
Add CryppushCoin (CPC)

### DIFF
--- a/src/tokens/pancakeswap-extended.json
+++ b/src/tokens/pancakeswap-extended.json
@@ -3422,5 +3422,13 @@
     "chainId": 56,
     "decimals": 8,
     "logoURI": "https://tokens.pancakeswap.finance/images/0x0555E30da8f98308EdB960aa94C0Db47230d2B9c.png"
+  },
+  {
+    "name": "CryppushCoin",
+    "symbol": "CPC",
+    "address": "0x1b6E8782b1BfA17b36473598E89652b899AeD786",
+    "chainId": 56,
+    "decimals": 18,
+    "logoURI": "https://cryppush.com/logo.png"
   }
 ]


### PR DESCRIPTION
CryppushCoin (CPC) is a utility token on BNB Smart Chain (BEP-20 standard), used across the Cryppush ecosystem — a suite of crypto automation and gamification tools including bot trading, staking, governance, and CPC Battle game.

✅ Token Details:
- Name: CryppushCoin
- Symbol: CPC
- Decimals: 18
- Contract: 0x1b6E8782b1BfA17b36473598E89652b899AeD786
- Chain: BNB Smart Chain (Chain ID: 56)
- Logo: https://cryppush.com/logo.png

🔗 Official Resources:
- Website: https://cryppush.com
- Twitter: https://x.com/cryppush
- Telegram: https://t.me/CryppushCoinHub
- Discord: https://discord.gg/u2yZSgac
- Whitepaper: https://cryppush.com/assets/files/CryppushCoin-Whitepaper.pdf
- Contact: support@cryppush.com

Let me know if any other documentation or verification is needed.