### PR TITLE
Add GoblinCoin (GOB) to pancake-extended token list

### DIFF
--- a/lists/pancakeswap-extended.json
+++ b/lists/pancakeswap-extended.json
@@ -1,4 +1,12 @@
 {
+  "chainId": 56,
+  "address": "0x24154433f7B51b069004747396D7eAcC349cb620",
+  "symbol": "GOB",
+  "name": "Goblin Coin",
+  "decimals": 18,
+  "logoURI": "https://ipfs.io/ipfs/Qm…/goblincoin.png"
+
+
   "name": "PancakeSwap Extended",
   "timestamp": "2024-09-19T10:57:12.436Z",
   "version": {


### PR DESCRIPTION
## Add GoblinCoin (GOB)

This PR adds GoblinCoin (GOB) to the pancake-extended token list.

- **Contract Address:** `0x24154433f7B51b069004747396D7eAcC349cb620`
- **Symbol:** `GOB`
- **Name:** `Goblin Coin`
- **Decimals:** `18`
- **Logo URI:** `https://ipfs.io/ipfs/QmYourHashHere/goblincoin.png`

Logo is hosted on IPFS at the above URI.

Thank you for reviewing!
![Uploading logo.png.png…]()
