### PR TITLE
Add NeWorldCoin (NWC) to token list

### DIFF
--- a/lists/nwc.tokenlist.json
+++ b/lists/nwc.tokenlist.json
@@ -1,6 +1,6 @@
 {
   "name": "NeWorldCoin Token List",
-  "logoURI": "https://raw.githubusercontent.com/NeWorldCoin/neworldcoin-assets/refs/heads/main/logo.svg",
+  "logoURI": "https://raw.githubusercontent.com/NeWorldCoin/neworldcoin-assets/main/logo.svg",
   "keywords": ["nwc", "neworldcoin", "bep20", "rewards", "crypto", "BNBChain"],
   "timestamp": "2025-08-05T00:00:00+00:00",
   "version": {
@@ -15,7 +15,7 @@
       "symbol": "NWC",
       "name": "NeWorldCoin",
       "decimals": 8,
-      "logoURI": "https://raw.githubusercontent.com/NeWorldCoin/neworldcoin-assets/refs/heads/main/logo.svg"
+      "logoURI": "https://raw.githubusercontent.com/NeWorldCoin/neworldcoin-assets/main/logo.svg"
     }
   ]
 }

--- a/lists/nwc.tokenlist.json
+++ b/lists/nwc.tokenlist.json
@@ -1,0 +1,21 @@
+{
+  "name": "NeWorldCoin Token List",
+  "logoURI": "https://raw.githubusercontent.com/NeWorldCoin/neworldcoin-assets/refs/heads/main/logo.svg",
+  "keywords": ["nwc", "neworldcoin", "bep20", "rewards", "crypto", "BNBChain"],
+  "timestamp": "2025-08-05T00:00:00+00:00",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "chainId": 56,
+      "address": "0xb22f7282aF0F418F13172Ff12D2b24655C0D30Ac",
+      "symbol": "NWC",
+      "name": "NeWorldCoin",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/NeWorldCoin/neworldcoin-assets/refs/heads/main/logo.svg"
+    }
+  ]
+}

--- a/lists/nwc.tokenlist.json
+++ b/lists/nwc.tokenlist.json
@@ -1,7 +1,7 @@
 {
   "name": "NeWorldCoin Token List",
   "logoURI": "https://raw.githubusercontent.com/NeWorldCoin/neworldcoin-assets/main/logo.svg",
-  "keywords": ["nwc", "neworldcoin", "bep20", "rewards", "crypto", "BNBChain"],
+  "keywords": "keywords": ["nwc", "NWC", "neworldcoin", "bep20", "rewards", "crypto", "BNBChain"],
   "timestamp": "2025-08-05T00:00:00+00:00",
   "version": {
     "major": 1,

--- a/token-lists.json
+++ b/token-lists.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "NeWorldCoin Token List",
+    "url": "https://raw.githubusercontent.com/NeWorldCoin/token-list/main/lists/nwc.tokenlist.json"
+  }
+]


### PR DESCRIPTION
This pull request adds the official NeWorldCoin (NWC) external token list to PancakeSwap.

🔹 Contract: `0xb22f7282aF0F418F13172Ff12D2b24655C0D30Ac`  
🔹 Chain ID: `56` (BNB Smart Chain)  
🔹 Decimals: `8`  
🔹 Token type: BEP-20  
🔹 Official logo: [SVG hosted on GitHub](https://raw.githubusercontent.com/NeWorldCoin/neworldcoin-assets/refs/heads/main/logo.svg)  
🔹 Token List URL: [nwc.tokenlist.json](https://raw.githubusercontent.com/NeWorldCoin/token-list/main/lists/nwc.tokenlist.json)

This list complies with the TokenList standard and PancakeSwap's external list requirements.
 
Thank you for considering our project!
