### PR TITLE
Add MUPI token to PancakeSwap Default List

### DIFF
--- a/lists/pancakeswap-default.json
+++ b/lists/pancakeswap-default.json
@@ -112,6 +112,20 @@
       "chainId": 56,
       "decimals": 18,
       "logoURI": "https://tokens.pancakeswap.finance/images/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d.png"
-    }
+    },
+{
+  "chainId": 56,
+  "address": "0x008E12860bA1B5Ce56D6bD35d64f99942D6a56bc",
+  "name": "MUPI",
+  "symbol": "MUPI",
+  "decimals": 18,
+  "logoURI": "https://raw.githubusercontent.com/agencywhitetarget-sketch/memcoinSlavCoin-SLAV-/main/mupi-logo.png",
+  "extensions": {
+    "website": "https://mupicoin.fun",
+    "telegram": "https://t.me/mupicoin",
+    "twitter": "https://x.com/mupicoin",
+    "description": "MUPI — AI × Pepe Meme Coin on BNB Chain. 0% tax, community-first."
+  }
+}
   ]
 }


### PR DESCRIPTION
This commit adds MUPI token information to the PancakeSwap Default List.

- Token name: MUPI
- Symbol: MUPI
- Chain: BNB Smart Chain (chainId 56)
- Contract: 0x008E12860bA1B5Ce56D6bD35d64f99942D6a56bc
- Decimals: 18
- Logo: https://raw.githubusercontent.com/agencywhitetarget-sketch/memcoinSlavCoin-SLAV/main/mupi-logo.png
- Website: https://mupicoin.fun
- Twitter: https://x.com/mupicoin
- Telegram: https://t.me/mupicoin
- Description: MUPI – AI × Pepe Meme Coin on BNB Chain. 0% tax, community-first.