### PR TITLE
Feat: add DiamondVault token list

### DIFF
--- a/lists/token-lists.json
+++ b/lists/token-lists.json
@@ -6,15 +6,17 @@
   "https://tokens.pancakeswap.finance/pancakeswap-extended.json": {
     "name": "PancakeSwap Extended",
     "homepage": "https://pancakeswap.finance"
-    
   },
   "https://tokens.pancakeswap.finance/pancakeswap-top-100.json": {
     "name": "PancakeSwap Top 100",
     "homepage": "https://pancakeswap.finance"
-    
   },
   "https://tokens.coingecko.com/binance-smart-chain/all.json": {
     "name": "CoinGecko",
     "homepage": "https://www.coingecko.com"
+  },
+  "https://raw.githubusercontent.com/DiamondVault/Dvault-Token-List/main/dvault-token-list.json": {
+    "name": "DiamondVault Tokens",
+    "homepage": "https://diamondvault.org"
   }
 }


### PR DESCRIPTION
This request adds the official DiamondVault token list. The list contains the token address, symbol, and a link to the official logo.