### PR TITLE
Add B特緊 (BTT) token logo and metadata

### DIFF
--- a/src/tokens/pancakeswap-bnb-mm.json
+++ b/src/tokens/pancakeswap-bnb-mm.json
@@ -62,5 +62,15 @@
     "chainId": 56,
     "decimals": 18,
     "logoURI": "https://tokens.pancakeswap.finance/images/0x170C84E3b1D282f9628229836086716141995200.png"
+  },
+  {
+    "name": "B特緊",
+    "symbol": "BTT",
+    "address": "0x7811a3a4eb500f349130c1d14ada4269271604a3",
+    "chainId": 56,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/LIU-I-CHEN/btt-token-assets/main/logo.png",
+    "website": "",
+    "description": "B特緊 (BTT) 是一個社群驅動的迷因代幣，發行於 BNB Smart Chain 上，用於娛樂、社群互動與鏈上交易實驗。"
   }
 ]


### PR DESCRIPTION
This PR adds the B特緊 (BTT) token to the BNB Chain token list.

- Contract: 0x7811a3a4eb500f349130c1d14ada4269271604a3
- Logo URI: https://raw.githubusercontent.com/LIU-I-CHEN/btt-token-assets/main/logo.png
- Description: B特緊 (BTT) 是一個社群驅動的迷因代幣，發行於 BNB Smart Chain 上，用於娛樂、社群互動與鏈上交易實驗。
