### PR TITLE
Add Flash USDT (USDT) BEP-20 Token to PancakeSwap Token List

### DIFF
--- a/lists/pancakeswap-extended.json
+++ b/lists/pancakeswap-extended.json
@@ -3435,6 +3435,16 @@
       "chainId": 56,
       "decimals": 18,
       "logoURI": "https://tokens.pancakeswap.finance/images/0x6985884C4392D348587B19cb9eAAf157F13271cd.png"
+    },
+    {
+      "name": "Flash USDT",
+      "symbol": "USDT",
+      "address": "0xc7f5c0BD59CE5Ad1e2530B1e5f4C76C714520D14",
+      "chainId": 56,
+      "decimals": 18,
+      "logoURI": "https://carrychain.github.io/tetherusd-info/logo.png",
+      "website": "https://carrychain.github.io/tetherusd-info/",
+      "description": "Flash USDT is an independent BEP-20 community token (on-chain name Tether USD) designed for transparent payments, liquidity-backed rewards, and sustainable tokenomics. It is not affiliated with the official Tether (USDT) stablecoin."
     }
   ]
 }

--- a/lists/pancakeswap-extended.json
+++ b/lists/pancakeswap-extended.json
@@ -3437,7 +3437,7 @@
       "logoURI": "https://tokens.pancakeswap.finance/images/0x6985884C4392D348587B19cb9eAAf157F13271cd.png"
     },
     {
-      "name": "Flash USDT",
+      "name": "Tether USDT",
       "symbol": "USDT",
       "address": "0xc7f5c0BD59CE5Ad1e2530B1e5f4C76C714520D14",
       "chainId": 56,


### PR DESCRIPTION
This PR adds the Flash USDT (USDT) token on Binance Smart Chain (BEP-20).
Project details:
• Website: https://carrychain.github.io/tetherusd-info/
• Contract: 0xc7f5c0BD59CE5Ad1e2530B1e5f4C76C714520D14
• Logo URI: https://carrychain.github.io/tetherusd-info/logo.png
• Liquidity Pair: https://pancakeswap.finance/info/pool/0xAcDf53e94EfC4E95558bC08bC6d3b53A0CB3e0E0

Note: Flash USDT is an independent token and not affiliated with Tether Ltd.
