### PR TITLE
Add One Metric Protocol token list

### DIFF
--- a/lists/token-lists.json
+++ b/lists/token-lists.json
@@ -6,15 +6,17 @@
   "https://tokens.pancakeswap.finance/pancakeswap-extended.json": {
     "name": "PancakeSwap Extended",
     "homepage": "https://pancakeswap.finance"
-    
   },
   "https://tokens.pancakeswap.finance/pancakeswap-top-100.json": {
     "name": "PancakeSwap Top 100",
     "homepage": "https://pancakeswap.finance"
-    
   },
   "https://tokens.coingecko.com/binance-smart-chain/all.json": {
     "name": "CoinGecko",
     "homepage": "https://www.coingecko.com"
+  },
+  "https://onemetric.org/tokenlist.json": {
+    "name": "One Metric Protocol",
+    "homepage": "https://onemetric.org"
   }
 }


### PR DESCRIPTION
Adding One Metric Protocol (OMP) token list hosted at https://onemetric.org/tokenlist.json

- Token: OMP (One Metric Protocol)
- Contract: 0x95cc1F0392BAC5212A04365c598fBC32ffE06D7d
- Chain: BSC (chainId: 56)
- Decimals: 18