### PR TITLE
Add Deutsche Mark token to pancakeswap-extended.json

### DIFF
--- a/lists/pancakeswap-extended.json
+++ b/lists/pancakeswap-extended.json
@@ -3435,6 +3435,14 @@
       "chainId": 56,
       "decimals": 18,
       "logoURI": "https://tokens.pancakeswap.finance/images/0x6985884C4392D348587B19cb9eAAf157F13271cd.png"
+    },
+    {
+      "name": "Deutsche Mark",
+      "symbol": "DDM",
+      "address": "0x9f1e8901e93a141c70cc90eee4c4cefd264b44d1",
+      "chainId": 56,
+      "decimals": 18,
+      "logoURI": "https://www.deutschemark-ddm.io/logo.png"
     }
   ]
 }


### PR DESCRIPTION
Project: Deutsche Mark (DDM)
Contract: 0x9f1e8901e93a141c70cc90eee4c4cefd264b44d1
Network: BSC (Chain ID 56)
Liquidity: $1.1M+ on PancakeSwap V3
Website: https://www.deutschemark-ddm.io/

Please add DDM to the extended token list. We have verified the on-chain liquidity and trading volume. Thank you!