### PR TITLE
feat: add wTBURN (Wrapped TBURN) token on BSC

### DIFF
--- a/src/tokens/pancakeswap-extended.json
+++ b/src/tokens/pancakeswap-extended.json
@@ -3422,5 +3422,13 @@
     "chainId": 56,
     "decimals": 8,
     "logoURI": "https://tokens.pancakeswap.finance/images/0x0555E30da8f98308EdB960aa94C0Db47230d2B9c.png"
+  },
+  {
+    "name": "Wrapped TBURN",
+    "symbol": "wTBURN",
+    "address": "0x1D2171D3645aC3216Ed87Dc81BbD3D9DF4085Fe2",
+    "chainId": 56,
+    "decimals": 18,
+    "logoURI": "https://tburn.io/TBURN_logo250x250.png"
   }
 ]


### PR DESCRIPTION
Add Wrapped TBURN (wTBURN) token to PancakeSwap extended token list.

- Token: wTBURN (Wrapped TBURN)
- Chain: BSC (chainId: 56)
- Contract: 0x1D2171D3645aC3216Ed87Dc81BbD3D9DF4085Fe2
- Decimals: 18
- Website: https://tburn.io
- Logo: https://tburn.io/TBURN_logo250x250.png