### PR TITLE
Add Everything (EV) token — Ethereum & Arbitrum

### DIFF
--- a/src/tokens/pancakeswap-arbitrum-default.json
+++ b/src/tokens/pancakeswap-arbitrum-default.json
@@ -486,5 +486,13 @@
     "chainId": 42161,
     "decimals": 18,
     "logoURI": "https://tokens.pancakeswap.finance/images/arbitrum/0x7E7a7C916c19a45769f6BDAF91087f93c6C12F78.png"
+  },
+  {
+    "name": "Everything",
+    "symbol": "EV",
+    "address": "0xE7E7E741C23a4767831A56A8C99F522c5aC1E7E7",
+    "chainId": 42161,
+    "decimals": 18,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39394.png"
   }
 ]

--- a/src/tokens/pancakeswap-eth-default.json
+++ b/src/tokens/pancakeswap-eth-default.json
@@ -638,5 +638,13 @@
     "chainId": 1,
     "decimals": 8,
     "logoURI": "https://tokens.pancakeswap.finance/images/eth/0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf.png"
+  },
+  {
+    "name": "Everything",
+    "symbol": "EV",
+    "address": "0xE7E7E741C23a4767831A56A8C99F522c5aC1E7E7",
+    "chainId": 1,
+    "decimals": 18,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39394.png"
   }
 ]


### PR DESCRIPTION
## Token Information

| Field | Value |
|---|---|
| **Name** | Everything |
| **Symbol** | EV |
| **Address** | `0xE7E7E741C23a4767831A56A8C99F522c5aC1E7E7` |
| **Decimals** | 18 |
| **Chains** | Ethereum (chainId: 1) + Arbitrum (chainId: 42161) |

## Links

- **Website:** https://everything.inc/
- **CoinMarketCap:** https://coinmarketcap.com/currencies/everything/ (#308, ~$62M market cap)
- **Etherscan:** https://etherscan.io/token/0xE7E7E741C23a4767831A56A8C99F522c5aC1E7E7
- **Arbiscan:** https://arbiscan.io/token/0xE7E7E741C23a4767831A56A8C99F522c5aC1E7E7

## Why add this token?

Everything (EV) is an ERC-20 token ranked #308 on CoinMarketCap with a market cap of ~$62M. It has ~2.26K holders on Arbitrum and active trading volume on Uniswap V4. The contract is verified on both Etherscan and Arbiscan.