### PR TITLE
Add Tetra USD (tUSD) to PancakeSwap token list

### DIFF
--- a/src/tokens/pancakeswap-extended.json
+++ b/src/tokens/pancakeswap-extended.json
@@ -3423,4 +3423,12 @@
     "decimals": 8,
     "logoURI": "https://tokens.pancakeswap.finance/images/0x0555E30da8f98308EdB960aa94C0Db47230d2B9c.png"
   }
+  {
+  "name": "Tetra USD",
+  "symbol": "tUSD",
+  "address": "0xba7D43Ac6D390aDaE143F4f68377a2a5B10EA046",
+  "chainId": 56,
+  "decimals": 6,
+  "logoURI": "https://raw.githubusercontent.com/USD-47/tusd-tokenlist/main/logo.png"
+}
 ]


### PR DESCRIPTION
Add Tetra USD (tUSD) token on BNB Smart Chain.

- Contract: 0xba7D43Ac6D390aDaE143F4f68377a2a5B10EA046
- Chain: BSC (56)
- Decimals: 6
- Logo: Included via GitHub

Token is active and ready for trading.