### PR TITLE
Add JCC (JiuCaiBi) token to BSC default list

### DIFF
--- a/src/tokens/pancakeswap-default.json
+++ b/src/tokens/pancakeswap-default.json
@@ -102,5 +102,13 @@
     "chainId": 56,
     "decimals": 18,
     "logoURI": "https://tokens.pancakeswap.finance/images/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d.png"
+  },
+  {
+    "name": "JiuCaiBi",
+    "symbol": "JCC",
+    "address": "0x992c30DD833E65586c6CEe32686dBE0cdCA077cc",
+    "chainId": 56,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/simonkang123/assets/jcc-0x992c30DD833E65586c6CEe32686dBE0cdCA077cc/blockchains/smartchain/assets/0x992c30DD833E65586c6CEe32686dBE0cdCA077cc/logo.png"
   }
 ]


### PR DESCRIPTION
## Token Information

| Field | Value |
|-------|-------|
| Name | JiuCaiBi |
| Symbol | JCC |
| Chain | BNB Smart Chain (56) |
| Contract | 0x992c30DD833E65586c6CEe32686dBE0cdCA077cc |
| Decimals | 18 |

BscScan: https://bscscan.com/token/0x992c30DD833E65586c6CEe32686dBE0cdCA077cc

Logo hosted via Trust Wallet assets PR.