### PR TITLE
Add Ice Snow Coin (ISC) external token list

### DIFF
--- a/lists/token-lists.json
+++ b/lists/token-lists.json
@@ -16,5 +16,9 @@
   "https://tokens.coingecko.com/binance-smart-chain/all.json": {
     "name": "CoinGecko",
     "homepage": "https://www.coingecko.com"
+  },
+  "https://icesnowcoin.com/tokenlist.json": {
+    "name": "Ice Snow Coin",
+    "homepage": "https://icesnowcoin.com"
   }
 }


### PR DESCRIPTION
## Description
Adding Ice Snow Coin (ISC) external token list URL to `token-lists.json`.

## Token List Details
- **List Name:** Ice Snow Coin
- **List URL:** https://icesnowcoin.com/tokenlist.json
- **Homepage:** https://icesnowcoin.com

## Token Information
- **Name:** Ice Snow Coin
- **Symbol:** ISC
- **Chain:** BNB Smart Chain (chainId: 56)
- **Contract Address:** 0x11229a3f976566FA8a3ba462C432122f3B8876f6
- **Decimals:** 18
- **Type:** BEP20

## Token List Schema
The token list hosted at the URL above follows the [Uniswap Token List Schema](https://github.com/Uniswap/token-lists) standard and includes proper version, name, timestamp, and token entries.

## Changes
- Modified `lists/token-lists.json` to add the Ice Snow Coin token list URL