### PR TITLE
Add 7SEVYN token to pancakeswap-extended.json

### DIFF
--- a/src/tokens/pancakeswap-extended.json
+++ b/src/tokens/pancakeswap-extended.json
@@ -3422,5 +3422,14 @@
     "chainId": 56,
     "decimals": 8,
     "logoURI": "https://tokens.pancakeswap.finance/images/0x0555E30da8f98308EdB960aa94C0Db47230d2B9c.png"
-  }
+  },
+    {
+        "name": "7SEVYN",
+        "symbol": "7SEVYN",
+        "address": "0x082c818a0bc956d6E7d1EBdBe89D3a24806B1484",
+        "chainId": 56,
+        "decimals": 18,
+        "logoURI": "https://7sevyncrypto.com/7SEVYN_logo_200px.png"
+    }
 ]
+


### PR DESCRIPTION
Token: 7SEVYN
Symbol: 7SEVYN
Chain: BNB Smart Chain (BSC)
Chain ID: 56
Contract: 0x082c818a0bc956d6E7d1EBdBe89D3a24806B1484
Decimals: 18
Website: https://7sevyncrypto.com
Logo: https://7sevyncrypto.com/7SEVYN_logo_200px.png

7SEVYN is a community-governed token on BSC. Contract is verified on BSCScan. Liquidity is locked. Third-party audit completed prior to launch.