### PR TITLE
feat: Add ISC (IceSnowCoin) to extended list

### DIFF
--- a/lists/pancakeswap-extended.json
+++ b/lists/pancakeswap-extended.json
@@ -1,10 +1,10 @@
 {
   "name": "PancakeSwap Extended",
-  "timestamp": "2024-09-19T10:57:12.436Z",
+  "timestamp": "2026-06-03T11:00:44.511Z",
   "version": {
     "major": 2,
     "minor": 16,
-    "patch": 245
+    "patch": 246
   },
   "logoURI": "https://pancakeswap.finance/logo.png",
   "keywords": [
@@ -3435,6 +3435,14 @@
       "chainId": 56,
       "decimals": 18,
       "logoURI": "https://tokens.pancakeswap.finance/images/0x6985884C4392D348587B19cb9eAAf157F13271cd.png"
-    }
+    },
+{
+  "name": "IceSnowCoin",
+  "symbol": "ISC",
+  "address": "0x11229a3f976566FA8a3ba462C432122f3B8876f6",
+  "chainId": 56,
+  "decimals": 18,
+  "logoURI": "https://tokens.pancakeswap.finance/images/0x11229a3f976566FA8a3ba462C432122f3B8876f6.png"
+}
   ]
 }

--- a/src/tokens/pancakeswap-extended.json
+++ b/src/tokens/pancakeswap-extended.json
@@ -3422,5 +3422,12 @@
     "chainId": 56,
     "decimals": 8,
     "logoURI": "https://tokens.pancakeswap.finance/images/0x0555E30da8f98308EdB960aa94C0Db47230d2B9c.png"
-  }
-]
+  },
+{
+  "name": "IceSnowCoin",
+  "symbol": "ISC",
+  "address": "0x11229a3f976566FA8a3ba462C432122f3B8876f6",
+  "chainId": 56,
+  "decimals": 18,
+  "logoURI": "https://tokens.pancakeswap.finance/images/0x11229a3f976566FA8a3ba462C432122f3B8876f6.png"
+}]


### PR DESCRIPTION
## Summary
Add ISC (IceSnowCoin) to PancakeSwap Extended Token List.

## Token Details
- **Name:** IceSnowCoin
- **Symbol:** ISC
- **Contract:** 0x11229a3f976566FA8a3ba462C432122f3B8876f6
- **Chain:** BNB Smart Chain (Chain ID: 56)
- **Decimals:** 18
- **Logo URI:** https://tokens.pancakeswap.finance/images/0x11229a3f976566FA8a3ba462C432122f3B8876f6.png

## Project Information
- **Website:** https://icesnowcoin.com
- **Twitter:** https://x.com/IceSnowCoin
- **Audit:** TechRate Security Audit Completed
- **Liquidity:** 40% LP locked via UNC, 20% Team tokens locked
- **Ownership:** Renounced (0x0000...0000)
- **Treasury:** 5/5 Multi-Sig Gnosis Safe (0x3B79D4A0bd73FCaB12DFEd34dA830b376A50e019)
- **CMC Submission:** Ticket #1369403 (submitted)

## Verification
- [x] Contract verified on BscScan
- [x] No duplicate address/symbol/name in list
- [x] Address is checksummed
- [x] Logo prepared (512x512 PNG, transparent background)

## Note
Contract ownership has been renounced for decentralization. Logo file available at: https://icesnowcoin.com/logo.png