### PR TITLE
feat: add MOCHI token to BNB Chain MM list

### DIFF
--- a/lists/pancakeswap-bnb-mm.json
+++ b/lists/pancakeswap-bnb-mm.json
@@ -76,6 +76,14 @@
       "chainId": 56,
       "decimals": 18,
       "logoURI": "https://tokens.pancakeswap.finance/images/0x170C84E3b1D282f9628229836086716141995200.png"
+    },
+    {
+      "name": "Mochi Token",
+      "symbol": "MOCHI",
+      "address": "0x80D953eEc21A67c54B04b18f64D39aE84ECAc441",
+      "chainId": 56,
+      "decimals": 18,
+      "logoURI": "https://olive-holy-platypus-289.mypinata.cloud/ipfs/bafybeicygbg5kw4b5wyzx7rsv7zen5qmgda6jkn57phoqhp67jji7fpefa"
     }
   ]
 }


### PR DESCRIPTION
Add MOCHI token to PancakeSwap BNB Chain MM list

- Name: Mochi Token
- Symbol: MOCHI
- Contract: 0x80D953eEc21A67c54B04b18f64D39aE84ECAc441
- ChainId: 56
- Decimals: 18
- Logo: IPFS via Pinata