### PR TITLE
Add CEXORDEX (CXDX) to PancakeSwap extended token list

### DIFF
--- a/src/tokens/pancakeswap-extended.json
+++ b/src/tokens/pancakeswap-extended.json
@@ -3422,5 +3422,13 @@
     "chainId": 56,
     "decimals": 8,
     "logoURI": "https://tokens.pancakeswap.finance/images/0x0555E30da8f98308EdB960aa94C0Db47230d2B9c.png"
-  }
+  },
+{
+  "name": "CEXORDEX",
+  "symbol": "CXDX",
+  "address": "0xd2d089F8E3DE35d06898FA91aCCC0bc3927C8e88",
+  "chainId": 56,
+  "decimals": 18,
+  "logoURI": "https://cexordex.com/assets/0xd2d089F8E3DE35d06898FA91aCCC0bc3927C8e88.png"
+}
 ]


### PR DESCRIPTION
Add CEXORDEX (CXDX) to PancakeSwap extended token list.

Token name: CEXORDEX

Symbol: CXDX

Chain: BNB Smart Chain

Contract: 0xd2d089F8E3DE35d06898FA91aCCC0bc3927C8e88

Decimals: 18

Website: https://cexordex.com

Logo: https://cexordex.com/assets/0xd2d089F8E3DE35d06898FA91aCCC0bc3927C8e88.png

GeckoTerminal verified pool:

https://www.geckoterminal.com/bsc/pools/0xb34a72778646a5513571c0fe5786fca9795bb20c