### PR TITLE
Add COSIGO CIGO external token list

### DIFF
--- a/lists/token-lists.json
+++ b/lists/token-lists.json
@@ -6,15 +6,17 @@
   "https://tokens.pancakeswap.finance/pancakeswap-extended.json": {
     "name": "PancakeSwap Extended",
     "homepage": "https://pancakeswap.finance"
-    
   },
   "https://tokens.pancakeswap.finance/pancakeswap-top-100.json": {
     "name": "PancakeSwap Top 100",
     "homepage": "https://pancakeswap.finance"
-    
   },
   "https://tokens.coingecko.com/binance-smart-chain/all.json": {
     "name": "CoinGecko",
     "homepage": "https://www.coingecko.com"
+  },
+  "https://market.cosigo.io/cigo-tokenlist.json": {
+    "name": "COSIGO CIGO",
+    "homepage": "https://market.cosigo.io"
   }
 }


### PR DESCRIPTION
This PR adds the official COSIGO / CIGO external token-list URL to token-lists.json.

Official token list:
https://market.cosigo.io/cigo-tokenlist.json

CIGO token:
0x3a38e963f524E0dDFB75dFa1752b4Cd1364F5560

Chain:
BNB Smart Chain

Official token notice:
https://market.cosigo.io/

Official swap:
https://trade.cosigo.io/

Official route review:
https://trade.cosigo.io/bnb-review.html

Official logo:
https://market.cosigo.io/shared/assets/icons/cigo_256.png

Reason:
CIGO is live and tradeable by address on PancakeSwap V2, but token metadata, search, icon, and price display remain inconsistent across PancakeSwap and wallet views. This PR follows the PancakeSwap token-list README guidance for adding an external token-list URL to token-lists.json.

I understand this is not a request for default-list inclusion unless the PancakeSwap team specifically asks for that path.