### PR TITLE
Add Quazenthor (QWBQ) educational token listCreate quazenthor.json

### DIFF
--- a/lists/quazenthor.json
+++ b/lists/quazenthor.json
@@ -1,11 +1,7 @@
 {
   "name": "Quazenthor List",
-  "timestamp": "2026-07-11T13:45:00Z",
-  "version": {
-    "major": 1,
-    "minor": 0,
-    "patch": 0
-  },
+  "timestamp": "2026-07-21T12:00:00Z",
+  "version": { "major": 1, "minor": 0, "patch": 0 },
   "tokens": [
     {
       "chainId": 56,
@@ -13,7 +9,7 @@
       "name": "quazenthor",
       "symbol": "QWBQ",
       "decimals": 18,
-      "logoURI": "https://quazenthor.com/logo.png"
+      "logoURI": "https://quazenthor.com/logo.svg"
     }
   ]
 }

--- a/lists/quazenthor.json
+++ b/lists/quazenthor.json
@@ -1,0 +1,19 @@
+{
+  "name": "Quazenthor List",
+  "timestamp": "2026-07-11T13:45:00Z",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "chainId": 56,
+      "address": "0x013f5f2F7F5b027012415A783ac2ed69EF936aE8",
+      "name": "quazenthor",
+      "symbol": "QWBQ",
+      "decimals": 18,
+      "logoURI": "https://quazenthor.com/logo.png"
+    }
+  ]
+}


### PR DESCRIPTION
Add Quazenthor (QWBQ) token list## Quazenthor (QWBQ) Token List

- **Name**: quazenthor  
- **Symbol**: QWBQ  
- **Contract Address**: `0x013f5f2F7F5b027012415A783ac2ed69EF936aE8`  
- **Chain**: BNB Smart Chain (56)  
- **Logo**: https://quazenthor.com/logo.png

This is a purely educational, non-financial BEP-20 reference token for learning blockchain standards. No trading, no liquidity pool, no investment intent.

Contract is verified on BscScan since January 2026.

Thank you for your review!