### PR TITLE
Add CatCoin official token list

### DIFF
--- a/lists/token-lists.json
+++ b/lists/token-lists.json
@@ -6,15 +6,17 @@
   "https://tokens.pancakeswap.finance/pancakeswap-extended.json": {
     "name": "PancakeSwap Extended",
     "homepage": "https://pancakeswap.finance"
-    
   },
   "https://tokens.pancakeswap.finance/pancakeswap-top-100.json": {
     "name": "PancakeSwap Top 100",
     "homepage": "https://pancakeswap.finance"
-    
   },
   "https://tokens.coingecko.com/binance-smart-chain/all.json": {
     "name": "CoinGecko",
     "homepage": "https://www.coingecko.com"
+  },
+  "https://catcoinbnb.com/token/tokenlist.json": {
+    "name": "CatCoin Official Token List",
+    "homepage": "https://catcoinbnb.com"
   }
 }


### PR DESCRIPTION
## Summary
- add the CatCoin official token list URL to `lists/token-lists.json`
- provide the official project homepage for list metadata

## Validation
- token list is publicly accessible over HTTPS
- JSON validates against the current `lists/tokenlist.schema.json`
- token logo URI returns HTTP 200
- BNB Smart Chain contract: `0x8d7Fc3008E3FB2C575114E2573374b7442E00FFc`

Token list: https://catcoinbnb.com/token/tokenlist.json

Homepage: https://catcoinbnb.com