### PR TITLE
Add AIW3 to PancakeSwap extended token list

### DIFF
--- a/src/tokens/pancakeswap-extended.json
+++ b/src/tokens/pancakeswap-extended.json
@@ -3422,5 +3422,13 @@
     "chainId": 56,
     "decimals": 8,
     "logoURI": "https://tokens.pancakeswap.finance/images/0x0555E30da8f98308EdB960aa94C0Db47230d2B9c.png"
+  },
+  {
+    "name": "AIW3",
+    "symbol": "AIW3",
+    "address": "0x37E94fc028903E74275478b65160D6d2c0e8880b",
+    "chainId": 56,
+    "decimals": 18,
+    "logoURI": "https://files.catbox.moe/n782ei.svg"
   }
 ]


### PR DESCRIPTION
## Summary

This PR adds AIW3 on BNB Smart Chain to the PancakeSwap extended token list.

Token details:
- Name: AIW3
- Symbol: AIW3
- Chain ID: 56
- Address: 0x37E94fc028903E74275478b65160D6d2c0e8880b
- Decimals: 18
- Website: https://aiw3.ai/
- BscScan: https://bscscan.com/token/0x37e94fc028903e74275478b65160d6d2c0e8880b
- CoinMarketCap: https://coinmarketcap.com/currencies/aiw3-ai/
- PancakeSwap liquidity pool: https://pancakeswap.finance/liquidity/pool/bsc/0x60F9c05EECe9a2594955d64eFe96e69a73BdAB44
- Trading pair: AIW3/USDT
- Logo URI: https://files.catbox.moe/n782ei.svg
- Website/socials: https://aiw3.ai/ · https://x.com/AIW3_official · https://t.me/AIW3_ai

## Test plan

- Ran `bun makelist pancakeswap-extended`
- Validation passed: 10 tests, 0 failures


Made with [Cursor](https://cursor.com)