### PR TITLE
feat: add Independent Dollar (IDOLL) to extended token list

### DIFF
--- a/src/tokens/pancakeswap-extended.json
+++ b/src/tokens/pancakeswap-extended.json
@@ -3422,5 +3422,14 @@
     "chainId": 56,
     "decimals": 8,
     "logoURI": "https://tokens.pancakeswap.finance/images/0x0555E30da8f98308EdB960aa94C0Db47230d2B9c.png"
+  },
+  {
+    "name": "Independent Dollar",
+    "symbol": "IDOLL",
+    "address": "0x8E9AdB904824fDfBEc1a5f15c4146a23dc3453EF",
+    "chainId": 56,
+    "decimals": 6,
+    "logoURI": "https://idfi.finance/img/idoll-token-logo-64.png"
   }
+]
 ]


### PR DESCRIPTION
Add Independent Dollar (IDOLL) on BNB Smart Chain to the PancakeSwap extended token list.

Token details:
- Name: Independent Dollar
- Symbol: IDOLL
- Chain ID: 56
- Decimals: 6
- Contract: 0x8E9AdB904824fDfBEc1a5f15c4146a23dc3453Ef
- Website: https://idfi.finance
- Logo: https://idfi.finance/img/idoll-token-logo-64.png

IDOLL is actively traded on PancakeSwap V3 against USDT.